### PR TITLE
🐛 Adapt archive grid to video count (no phantom trailing column)

### DIFF
--- a/css/training-videos.css
+++ b/css/training-videos.css
@@ -350,6 +350,18 @@ a.hover\:bg-beige\/50:hover { background-color: rgba(253, 249, 227, 0.50); }
 .btn:hover { background: var(--tv-color-brick); color: var(--tv-color-white); }
 
 /* ---------------------------------------------------------- */
+/* Archive grid — adaptive to video count                     */
+/* ---------------------------------------------------------- */
+
+/* Single-video case: center one card at a comfortable reading width
+   so it doesn't stretch full-bleed on desktop. */
+.tv-grid-single {
+	max-width: 22rem;
+	margin-left: auto;
+	margin-right: auto;
+}
+
+/* ---------------------------------------------------------- */
 /* Responsive                                                 */
 /* ---------------------------------------------------------- */
 
@@ -371,5 +383,6 @@ a.hover\:bg-beige\/50:hover { background-color: rgba(253, 249, 227, 0.50); }
 	.lg\:block { display: block; }
 	.lg\:sticky { position: sticky; }
 	.lg\:top-24 { top: 6rem; }
+	.lg\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
 	.lg\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
 }

--- a/templates/archive-training_videos.php
+++ b/templates/archive-training_videos.php
@@ -115,8 +115,25 @@ include plugin_dir_path( __FILE__ ) . 'training-header.php';
 	<?php endif; ?>
 
 	<?php if ( have_posts() ) : ?>
+		<?php
+		// Adapt grid columns to video count so a sparse library doesn't leave a
+		// dead trailing column. 1 → centered single card, 2 → halves, 3 → thirds,
+		// 4+ → quarters. wp_count_posts() returns strings, so int-cast first.
+		$count_int  = (int) $video_count;
+		$grid_class = 'grid grid-cols-1 gap-6 tv-grid';
+		if ( $count_int >= 4 ) {
+			$grid_class .= ' md:grid-cols-2 lg:grid-cols-4';
+		} elseif ( 3 === $count_int ) {
+			$grid_class .= ' md:grid-cols-2 lg:grid-cols-3';
+		} elseif ( 2 === $count_int ) {
+			$grid_class .= ' md:grid-cols-2';
+		} else {
+			// Single video — center it with a max-width so it doesn't stretch full bleed.
+			$grid_class .= ' tv-grid-single';
+		}
+		?>
 		<!-- Video Grid -->
-		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+		<div class="<?php echo esc_attr( $grid_class ); ?>">
 			<?php
 			while ( have_posts() ) :
 				the_post();


### PR DESCRIPTION
## Summary

Archive grid was always 4 columns at \`lg+\`. Clients with 1-3 videos got a dead empty trailing column. Derive the grid class from \`\$video_count\`:

| Count | Behavior |
|---|---|
| 1 | Centered single card, max-width \`22rem\` |
| 2 | \`md:grid-cols-2\` |
| 3 | \`md:grid-cols-2 lg:grid-cols-3\` |
| 4+ | \`md:grid-cols-2 lg:grid-cols-4\` (unchanged) |

\`wp_count_posts()\` returns string values on modern PHP, so I int-cast before strict comparison — without that, every conditional fell through to the single-video branch.

**Stacked on \`chore/v1.1.2-styling-baseline\`** (PR #19) — when that merges to main, GitHub auto-retargets this PR.

## Test plan

- [x] Demo with 3 videos: 3 columns at 1280px, no empty 4th column
- [x] Mobile (375px) still single column
- [ ] Eric eyeballs other counts (1, 2, 4+) — currently only 3 in the demo seed
- [ ] Console clean

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)