### PR TITLE
🐛 Keep header nav labels visible at every viewport

### DIFF
--- a/css/training-videos.css
+++ b/css/training-videos.css
@@ -240,6 +240,7 @@ body.single-training_videos iframe {
 .bg-navy\/20 { background-color: rgba(17, 45, 64, 0.20); }
 .bg-white\/10 { background-color: rgba(255, 255, 255, 0.10); }
 .bg-white\/20 { background-color: rgba(255, 255, 255, 0.20); }
+.bg-white\/30 { background-color: rgba(255, 255, 255, 0.30); }
 .bg-beige\/50 { background-color: rgba(253, 249, 227, 0.50); }
 .bg-beige\/70 { background-color: rgba(253, 249, 227, 0.70); }
 
@@ -325,6 +326,7 @@ a:hover .group-hover\:scale-105,
 
 a.hover\:bg-stone-blue:hover { background-color: var(--tv-color-stone-blue); }
 a.hover\:bg-white\/20:hover { background-color: rgba(255, 255, 255, 0.20); }
+a.hover\:bg-white\/30:hover { background-color: rgba(255, 255, 255, 0.30); }
 a.hover\:text-orange:hover { color: var(--tv-color-orange); }
 a.hover\:text-white:hover { color: var(--tv-color-white); }
 a.hover\:text-brick:hover { color: var(--tv-color-brick); }
@@ -348,6 +350,25 @@ a.hover\:bg-beige\/50:hover { background-color: rgba(253, 249, 227, 0.50); }
 	transition: background-color 200ms ease;
 }
 .btn:hover { background: var(--tv-color-brick); color: var(--tv-color-white); }
+
+/* ---------------------------------------------------------- */
+/* Header nav links — keep labels visible at every viewport   */
+/* ---------------------------------------------------------- */
+
+.tv-header-link {
+	min-height: 44px; /* ≥44px tap target on mobile */
+	white-space: nowrap;
+}
+
+/* On very narrow viewports the brand block + 2 nav buttons can crowd. Tighten
+   padding so labels stay legible without overflowing. */
+@media (max-width: 480px) {
+	.tv-header-link {
+		padding-left: 0.625rem;
+		padding-right: 0.625rem;
+		font-size: 0.8125rem;
+	}
+}
 
 /* ---------------------------------------------------------- */
 /* Responsive                                                 */

--- a/templates/training-header.php
+++ b/templates/training-header.php
@@ -29,15 +29,19 @@
 
 				<!-- Navigation -->
 				<nav class="flex gap-2 items-center">
-					<a href="<?php echo esc_url( home_url() ); ?>" class="inline-flex items-center gap-2 px-4 py-2 text-white/80 hover:text-white transition-colors text-sm">
-						<i class="fa-sharp fa-solid fa-arrow-left"></i>
-						<span class="hidden sm:inline">Back to Site</span>
+					<a href="<?php echo esc_url( home_url() ); ?>"
+					   class="tv-header-link inline-flex items-center gap-2 px-3 py-2 text-white/80 hover:text-white transition-colors text-sm"
+					   aria-label="Back to main site">
+						<i class="fa-sharp fa-solid fa-arrow-left" aria-hidden="true"></i>
+						<span>Back to Site</span>
 					</a>
 
 					<?php if ( current_user_can( 'manage_options' ) ) : ?>
-						<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=training_videos' ) ); ?>" class="inline-flex items-center gap-2 px-4 py-2 bg-white/10 text-white rounded hover:bg-white/20 transition-colors text-sm">
-							<i class="fa-sharp fa-solid fa-gear"></i>
-							<span class="hidden sm:inline">Manage</span>
+						<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=training_videos' ) ); ?>"
+						   class="tv-header-link inline-flex items-center gap-2 px-3 py-2 bg-white/20 text-white rounded hover:bg-white/30 transition-colors text-sm"
+						   aria-label="Manage training videos in admin">
+							<i class="fa-sharp fa-solid fa-gear" aria-hidden="true"></i>
+							<span>Manage</span>
 						</a>
 					<?php endif; ?>
 				</nav>


### PR DESCRIPTION
## Summary

Mobile (<640px) hid \"Back to Site\" / \"Manage\" labels via \`hidden sm:inline\`, leaving icon-only buttons that were nearly invisible against the navy header (\`bg-white/10\` is ~10% opacity white on navy — very low contrast). Clients had no idea either button existed.

- Drop the \`hidden sm:inline\` class on both labels
- Boost the Manage button contrast: \`bg-white/10\` → \`bg-white/20\` (hover \`/30\`)
- Tighten padding at <480px so labels stay legible without overflow
- Enforce min-height 44px for proper tap target (a11y)
- Add \`aria-label\` on the wrapper link, \`aria-hidden\` on the decorative icons

**Stacked on \`chore/v1.1.2-styling-baseline\`** (PR #19).

## Test plan

- [x] Both labels visible and readable at 375px
- [x] Icons render alongside (FA gear + arrow-left)
- [x] Tap targets ≥ 44px
- [x] Manage button still admin-only (\`current_user_can('manage_options')\` gate unchanged)
- [x] Desktop unchanged
- [ ] Eric eyeballs

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)