### PR TITLE
✨ Lazy-load Loom iframe on click — show poster + play overlay

### DIFF
--- a/css/training-videos.css
+++ b/css/training-videos.css
@@ -350,6 +350,132 @@ a.hover\:bg-beige\/50:hover { background-color: rgba(253, 249, 227, 0.50); }
 .btn:hover { background: var(--tv-color-brick); color: var(--tv-color-white); }
 
 /* ---------------------------------------------------------- */
+/* Loom poster — lazy-load click-to-play                      */
+/* ---------------------------------------------------------- */
+
+.tv-poster-wrap {
+	position: relative;
+	width: 100%;
+}
+
+.tv-poster {
+	display: block;
+	position: relative;
+	width: 100%;
+	padding: 0;
+	margin: 0;
+	border: 0;
+	background: var(--tv-color-navy);
+	cursor: pointer;
+	overflow: hidden;
+	aspect-ratio: 16 / 9;
+	font: inherit;
+	color: inherit;
+}
+
+/* Older browsers without aspect-ratio support — keep the 56.25% padding-hack ratio */
+@supports not (aspect-ratio: 16 / 9) {
+	.tv-poster {
+		aspect-ratio: auto;
+		padding-bottom: 56.25%;
+		height: 0;
+	}
+}
+
+.tv-poster__img {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	display: block;
+	transition: transform 400ms ease, opacity 200ms ease;
+}
+
+.tv-poster:hover .tv-poster__img,
+.tv-poster:focus-visible .tv-poster__img {
+	transform: scale(1.02);
+}
+
+.tv-poster__overlay {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: rgba(17, 45, 64, 0.30);
+	transition: background-color 200ms ease;
+}
+
+.tv-poster:hover .tv-poster__overlay,
+.tv-poster:focus-visible .tv-poster__overlay {
+	background: rgba(17, 45, 64, 0.45);
+}
+
+.tv-poster__play {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 5rem;
+	height: 5rem;
+	border-radius: 9999px;
+	background: var(--tv-color-orange);
+	color: var(--tv-color-navy);
+	box-shadow: 0 12px 24px -8px rgba(17, 45, 64, 0.45);
+	transition: transform 200ms ease, background-color 200ms ease;
+}
+
+.tv-poster:hover .tv-poster__play,
+.tv-poster:focus-visible .tv-poster__play {
+	transform: scale(1.08);
+	background: var(--tv-color-brick);
+	color: var(--tv-color-white);
+}
+
+.tv-poster__play .fa-play {
+	font-size: 1.5rem;
+	margin-left: 0.25rem; /* optical centering for the play triangle */
+}
+
+.tv-poster:focus-visible {
+	outline: 3px solid var(--tv-color-orange);
+	outline-offset: 2px;
+}
+
+/* Empty state — no Loom URL set yet */
+.tv-poster--empty {
+	cursor: default;
+	background: var(--tv-color-linen);
+	color: var(--tv-color-stone-blue);
+}
+
+.tv-poster__empty {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	text-align: center;
+}
+
+/* Once swapped to an iframe, take the same aspect ratio */
+.tv-poster-wrap iframe {
+	display: block;
+	width: 100%;
+	aspect-ratio: 16 / 9;
+	border: 0;
+}
+
+@supports not (aspect-ratio: 16 / 9) {
+	.tv-poster-wrap iframe {
+		aspect-ratio: auto;
+		padding-bottom: 56.25%;
+		height: 0;
+	}
+}
+
+/* ---------------------------------------------------------- */
 /* Responsive                                                 */
 /* ---------------------------------------------------------- */
 

--- a/inc/loom-helpers.php
+++ b/inc/loom-helpers.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Loom helpers — thumbnail fetching via oEmbed.
+ *
+ * Used by archive + single templates so we only have one implementation.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! function_exists( 'training_videos_get_loom_thumbnail_url' ) ) {
+	/**
+	 * Get a thumbnail URL for a Loom video.
+	 *
+	 * Loom's plain-ID thumbnails (e.g. {id}-with-play.gif) return HTTP 403 for
+	 * workspace-private videos. The oEmbed endpoint returns a hash-suffixed
+	 * thumbnail that is publicly accessible regardless of video privacy, so we
+	 * use that and cache for 7 days via WP transient. Failures are cached for
+	 * 5 minutes so a stale 403 doesn't stick.
+	 *
+	 * @param string $video_url Loom share or embed URL.
+	 * @return string|false Thumbnail URL on success, false otherwise.
+	 */
+	function training_videos_get_loom_thumbnail_url( $video_url ) {
+		if ( empty( $video_url ) ) {
+			return false;
+		}
+		if ( strpos( $video_url, 'loom.com' ) === false ) {
+			return false;
+		}
+		if ( ! preg_match( '/loom\.com\/(?:embed|share)\/([a-zA-Z0-9]+)/', $video_url, $matches ) ) {
+			return false;
+		}
+		$video_id = $matches[1];
+
+		$cache_key = 'training_video_thumb_' . $video_id;
+		$cached    = get_transient( $cache_key );
+		if ( false !== $cached ) {
+			return $cached ?: false;
+		}
+
+		$share_url = 'https://www.loom.com/share/' . $video_id;
+		$response  = wp_remote_get(
+			'https://www.loom.com/v1/oembed?url=' . rawurlencode( $share_url ),
+			array( 'timeout' => 5 )
+		);
+
+		$thumb = '';
+		if ( ! is_wp_error( $response ) && 200 === wp_remote_retrieve_response_code( $response ) ) {
+			$body = json_decode( wp_remote_retrieve_body( $response ), true );
+			if ( ! empty( $body['thumbnail_url'] ) ) {
+				$thumb = $body['thumbnail_url'];
+			}
+		}
+
+		set_transient(
+			$cache_key,
+			$thumb,
+			$thumb ? 7 * DAY_IN_SECONDS : 5 * MINUTE_IN_SECONDS
+		);
+		return $thumb ?: false;
+	}
+}
+
+if ( ! function_exists( 'get_video_thumbnail_url' ) ) {
+	/**
+	 * Backwards-compat alias. Old code (and the archive template before #15)
+	 * called this unprefixed name. Keep it as a thin wrapper so any external
+	 * customizations don't break.
+	 */
+	function get_video_thumbnail_url( $video_url ) {
+		return training_videos_get_loom_thumbnail_url( $video_url );
+	}
+}

--- a/templates/archive-training_videos.php
+++ b/templates/archive-training_videos.php
@@ -11,52 +11,7 @@ if ( ! is_user_logged_in() ) {
 	exit;
 }
 
-/**
- * Get thumbnail URL for a Loom video.
- *
- * Loom's plain-ID thumbnails (e.g. {id}-with-play.gif) return HTTP 403 for
- * workspace-private videos. The oEmbed endpoint returns a hash-suffixed
- * thumbnail that is publicly accessible regardless of video privacy, so we
- * use that and cache for 7 days via WP transient.
- */
-function get_video_thumbnail_url( $video_url ) {
-	if ( empty( $video_url ) ) {
-		return false;
-	}
-
-	if ( strpos( $video_url, 'loom.com' ) === false ) {
-		return false;
-	}
-
-	if ( ! preg_match( '/loom\.com\/(?:embed|share)\/([a-zA-Z0-9]+)/', $video_url, $matches ) ) {
-		return false;
-	}
-	$video_id = $matches[1];
-
-	$cache_key = 'training_video_thumb_' . $video_id;
-	$cached    = get_transient( $cache_key );
-	if ( false !== $cached ) {
-		return $cached ?: false;
-	}
-
-	$share_url = 'https://www.loom.com/share/' . $video_id;
-	$response  = wp_remote_get(
-		'https://www.loom.com/v1/oembed?url=' . rawurlencode( $share_url ),
-		array( 'timeout' => 5 )
-	);
-
-	$thumb = '';
-	if ( ! is_wp_error( $response ) && 200 === wp_remote_retrieve_response_code( $response ) ) {
-		$body = json_decode( wp_remote_retrieve_body( $response ), true );
-		if ( ! empty( $body['thumbnail_url'] ) ) {
-			$thumb = $body['thumbnail_url'];
-		}
-	}
-
-	// Cache success for 7 days, failure for 5 minutes (so a stale 403 doesn't stick).
-	set_transient( $cache_key, $thumb, $thumb ? 7 * DAY_IN_SECONDS : 5 * MINUTE_IN_SECONDS );
-	return $thumb ?: false;
-}
+// Thumbnail helper lives in inc/loom-helpers.php (loaded by training-videos.php).
 
 // Include header
 include plugin_dir_path( __FILE__ ) . 'training-header.php';

--- a/templates/single-training_videos.php
+++ b/templates/single-training_videos.php
@@ -112,26 +112,46 @@ include plugin_dir_path( __FILE__ ) . 'training-header.php';
 					<?php endif; ?>
 				</div>
 
-				<!-- Video Embed -->
+				<!-- Video Embed (lazy-loaded — click poster to load iframe) -->
 				<?php
 				$loom_video_url = get_post_meta( get_the_ID(), '_loom_video_url', true );
 				if ( $loom_video_url ) :
+					$thumbnail_url = training_videos_get_loom_thumbnail_url( $loom_video_url );
+					$embed_url     = add_query_arg(
+						array(
+							'hide_owner'       => 'true',
+							'hide_share'       => 'true',
+							'hide_title'       => 'true',
+							'hideEmbedTopBar'  => 'true',
+						),
+						$loom_video_url
+					);
 					?>
-					<div class="mb-8 rounded-lg overflow-hidden shadow-lg" style="position: relative; padding-bottom: 56.25%; height: 0; background: #112D40;">
-						<iframe src="<?php echo esc_url( $loom_video_url ); ?>?hide_owner=true&hide_share=true&hide_title=true&hideEmbedTopBar=true"
-								title="<?php the_title_attribute(); ?>"
-								frameborder="0"
-								webkitallowfullscreen
-								mozallowfullscreen
-								allowfullscreen
-								style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
-						</iframe>
+					<div class="tv-poster-wrap mb-8 rounded-lg overflow-hidden shadow-lg">
+						<button type="button"
+								class="tv-poster"
+								data-embed="<?php echo esc_url( $embed_url ); ?>"
+								aria-label="Play video: <?php echo esc_attr( get_the_title() ); ?>">
+							<?php if ( $thumbnail_url ) : ?>
+								<img class="tv-poster__img"
+									 src="<?php echo esc_url( $thumbnail_url ); ?>"
+									 alt=""
+									 loading="lazy" />
+							<?php endif; ?>
+							<span class="tv-poster__overlay" aria-hidden="true">
+								<span class="tv-poster__play">
+									<i class="fa-sharp fa-solid fa-play"></i>
+								</span>
+							</span>
+						</button>
 					</div>
 				<?php else : ?>
-					<div class="mb-8 rounded-lg overflow-hidden bg-linen flex items-center justify-center" style="position: relative; padding-bottom: 56.25%; height: 0;">
-						<div class="absolute inset-0 flex flex-col items-center justify-center text-stone-blue">
-							<i class="fa-sharp fa-solid fa-video-slash text-5xl mb-3"></i>
-							<p class="text-lg">No video available</p>
+					<div class="tv-poster-wrap mb-8 rounded-lg overflow-hidden">
+						<div class="tv-poster tv-poster--empty" aria-hidden="true">
+							<div class="tv-poster__empty">
+								<i class="fa-sharp fa-solid fa-video-slash text-5xl mb-3"></i>
+								<p class="text-lg">No video available</p>
+							</div>
 						</div>
 					</div>
 				<?php endif; ?>
@@ -185,6 +205,30 @@ include plugin_dir_path( __FILE__ ) . 'training-header.php';
 		</div>
 	</div>
 </div>
+
+<script>
+/**
+ * Lazy-load the Loom iframe on click. Until clicked, only the poster image +
+ * a play button render — no Loom JS, no third-party network requests.
+ */
+(function () {
+	var posters = document.querySelectorAll( '.tv-poster[data-embed]' );
+	Array.prototype.forEach.call( posters, function ( btn ) {
+		btn.addEventListener( 'click', function () {
+			var embedUrl = btn.getAttribute( 'data-embed' );
+			if ( ! embedUrl ) { return; }
+			var sep   = embedUrl.indexOf( '?' ) === -1 ? '?' : '&';
+			var iframe = document.createElement( 'iframe' );
+			iframe.src           = embedUrl + sep + 'autoplay=1';
+			iframe.title         = btn.getAttribute( 'aria-label' ) || 'Video';
+			iframe.allow         = 'autoplay; fullscreen; picture-in-picture';
+			iframe.allowFullscreen = true;
+			iframe.setAttribute( 'frameborder', '0' );
+			btn.replaceWith( iframe );
+		} );
+	} );
+})();
+</script>
 
 <?php
 // Include footer

--- a/training-videos.php
+++ b/training-videos.php
@@ -14,6 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+require_once plugin_dir_path( __FILE__ ) . 'inc/loom-helpers.php';
+
 
 
 // Enqueue self-contained styles + Font Awesome only on plugin pages.


### PR DESCRIPTION
## Summary

Loom iframe rendered as a solid navy block on first paint until clicked — looked broken. Replace with a click-to-play pattern: oEmbed thumbnail + centered orange play button. Iframe only loads when the user clicks, autoplaying via \`?autoplay=1\`.

**Wins:**
- First-paint feels like a video, not a broken embed
- No third-party Loom JS until the user opts in (faster initial page weight)
- Brand-consistent play button reuses \`--tv-color-orange\` / \`--tv-color-brick\` tokens
- Proper a11y: native \`<button>\`, descriptive \`aria-label\`, \`focus-visible\` outline
- Works on browsers without \`aspect-ratio\` support via graceful padding-hack fallback

**Refactor:**
- Extracted \`get_video_thumbnail_url()\` from \`archive-training_videos.php\` to a shared \`inc/loom-helpers.php\` as \`training_videos_get_loom_thumbnail_url()\` (prefixed)
- Kept \`get_video_thumbnail_url()\` as a backwards-compat alias so any external customizations don't break
- Archive template no longer carries its own copy of the helper

**Stacked on \`chore/v1.1.2-styling-baseline\`** (PR #19).

## Test plan

- [x] Single page first paint: thumbnail visible immediately + orange play button overlay
- [x] Click play → iframe loads, autoplays (\`Pause\` button focused, \`0:02 of 0:32\` shown)
- [x] Embed URL preserves \`hide_owner=true&hide_share=true&hide_title=true&hideEmbedTopBar=true\` then appends \`&autoplay=1\`
- [x] Hover state: poster scales 1.02 + play button scales 1.08, color shifts to brick
- [x] Empty state (no Loom URL set) still renders gracefully
- [ ] Eric eyeballs

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)