### PR TITLE
🐛 Stack PREV/NEXT pager full-width on mobile (no mid-word truncation)

### DIFF
--- a/css/training-videos.css
+++ b/css/training-videos.css
@@ -350,6 +350,55 @@ a.hover\:bg-beige\/50:hover { background-color: rgba(253, 249, 227, 0.50); }
 .btn:hover { background: var(--tv-color-brick); color: var(--tv-color-white); }
 
 /* ---------------------------------------------------------- */
+/* Pager — PREV / NEXT navigation                             */
+/* ---------------------------------------------------------- */
+
+/* Mobile-first: stacked column, full-width items, no truncation */
+.tv-pager {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.tv-pager__item {
+	width: 100%;
+	min-height: 64px;
+	text-decoration: none;
+}
+
+.tv-pager__item--next {
+	text-align: right;
+}
+
+/* Title can break onto 2 lines without truncating mid-word */
+.tv-pager__title {
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+	word-break: normal;
+	overflow-wrap: anywhere;
+}
+
+/* Tablet+: side-by-side, justified */
+@media (min-width: 768px) {
+	.tv-pager {
+		flex-direction: row;
+		justify-content: space-between;
+		align-items: stretch;
+	}
+
+	.tv-pager__item {
+		flex: 1 1 0%;
+		max-width: calc(50% - 0.5rem);
+	}
+
+	/* Single-button case (first or last video): keep its natural side */
+	.tv-pager__item--prev:only-child { margin-right: auto; }
+	.tv-pager__item--next:only-child { margin-left: auto; }
+}
+
+/* ---------------------------------------------------------- */
 /* Responsive                                                 */
 /* ---------------------------------------------------------- */
 

--- a/templates/single-training_videos.php
+++ b/templates/single-training_videos.php
@@ -143,32 +143,30 @@ include plugin_dir_path( __FILE__ ) . 'training-header.php';
 					</div>
 				<?php endif; ?>
 
-				<!-- Navigation -->
-				<nav class="flex justify-between items-stretch gap-4 pt-8 border-t border-linen">
+				<!-- Navigation: stacks full-width on mobile, side-by-side at md+ -->
+				<nav class="tv-pager pt-8 border-t border-linen">
 					<?php if ( $prev_video ) : ?>
 						<a href="<?php echo esc_url( get_permalink( $prev_video->ID ) ); ?>"
-						   class="flex items-center gap-3 p-4 bg-white border border-linen rounded-lg hover:border-orange transition-all group" style="max-width: 45%;">
-							<span class="flex-shrink-0 w-10 h-10 rounded-full bg-linen flex items-center justify-center group-hover:bg-orange transition-colors">
-								<i class="fa-sharp fa-solid fa-arrow-left text-stone-blue group-hover:text-navy transition-colors"></i>
+						   class="tv-pager__item tv-pager__item--prev group flex items-center gap-3 p-4 bg-white border border-linen rounded-lg hover:border-orange transition-all">
+							<span class="tv-pager__icon flex-shrink-0 w-10 h-10 rounded-full bg-linen flex items-center justify-center group-hover:bg-orange transition-colors">
+								<i class="fa-sharp fa-solid fa-arrow-left text-stone-blue group-hover:text-navy transition-colors" aria-hidden="true"></i>
 							</span>
-							<span class="min-w-0">
+							<span class="tv-pager__text min-w-0">
 								<span class="text-xs text-stone-blue uppercase tracking-wide block">Previous</span>
-								<span class="text-navy font-medium text-sm truncate block"><?php echo esc_html( $prev_video->post_title ); ?></span>
+								<span class="tv-pager__title text-navy font-medium text-sm leading-tight block"><?php echo esc_html( $prev_video->post_title ); ?></span>
 							</span>
 						</a>
-					<?php else : ?>
-						<span></span>
 					<?php endif; ?>
 
 					<?php if ( $next_video ) : ?>
 						<a href="<?php echo esc_url( get_permalink( $next_video->ID ) ); ?>"
-						   class="flex items-center gap-3 p-4 bg-white border border-linen rounded-lg hover:border-orange transition-all group text-right" style="max-width: 45%;">
-							<span class="min-w-0">
+						   class="tv-pager__item tv-pager__item--next group flex items-center gap-3 p-4 bg-white border border-linen rounded-lg hover:border-orange transition-all">
+							<span class="tv-pager__text min-w-0">
 								<span class="text-xs text-stone-blue uppercase tracking-wide block">Next</span>
-								<span class="text-navy font-medium text-sm truncate block"><?php echo esc_html( $next_video->post_title ); ?></span>
+								<span class="tv-pager__title text-navy font-medium text-sm leading-tight block"><?php echo esc_html( $next_video->post_title ); ?></span>
 							</span>
-							<span class="flex-shrink-0 w-10 h-10 rounded-full bg-linen flex items-center justify-center group-hover:bg-orange transition-colors">
-								<i class="fa-sharp fa-solid fa-arrow-right text-stone-blue group-hover:text-navy transition-colors"></i>
+							<span class="tv-pager__icon flex-shrink-0 w-10 h-10 rounded-full bg-linen flex items-center justify-center group-hover:bg-orange transition-colors">
+								<i class="fa-sharp fa-solid fa-arrow-right text-stone-blue group-hover:text-navy transition-colors" aria-hidden="true"></i>
 							</span>
 						</a>
 					<?php endif; ?>


### PR DESCRIPTION
## Summary

On mobile (375px), the side-by-side PREV/NEXT cards truncated video titles mid-word — \"Welcome to you...\", \"Updating image...\" Looked amateur. Stack vertically on mobile so each card is full-width and titles can wrap to 2 lines.

- Wrap nav with \`.tv-pager\` (flex column on mobile, row at \`md+\`)
- Drop inline \`style=\"max-width: 45%\"\` — handled responsively now
- Replace \`truncate\` with \`line-clamp-2\` + \`overflow-wrap: anywhere\`
- Min-height 64px for proper tap target (a11y)
- Empty \`<span></span>\` placeholder removed; CSS positions the single-button case (first/last video)

**Stacked on \`chore/v1.1.2-styling-baseline\`** (PR #19).

## Test plan

- [x] 375px: PREV stacks above NEXT, each full-width, full title visible (max 2 lines)
- [x] 1280px: side-by-side as before, titles still readable
- [x] First video (no PREV): only NEXT renders, layout doesn't break
- [x] Last video (no NEXT): only PREV renders, layout doesn't break
- [ ] Eric eyeballs

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)