### PR TITLE
🐛 Reduce empty space below content + Back to all videos link

### DIFF
--- a/css/training-videos.css
+++ b/css/training-videos.css
@@ -350,6 +350,41 @@ a.hover\:bg-beige\/50:hover { background-color: rgba(253, 249, 227, 0.50); }
 .btn:hover { background: var(--tv-color-brick); color: var(--tv-color-white); }
 
 /* ---------------------------------------------------------- */
+/* Main wrapper — no forced full-viewport height              */
+/* ---------------------------------------------------------- */
+
+/* Was .min-h-screen — pages ended early so the footer floated mid-viewport
+   on tall screens. Use a modest floor instead so a near-empty archive still
+   has presence but a typical archive ends naturally above the footer. */
+.tv-main {
+	min-height: 400px;
+}
+
+/* ---------------------------------------------------------- */
+/* "Back to all videos" link at bottom of single pages        */
+/* ---------------------------------------------------------- */
+
+.tv-back-link__a {
+	color: var(--tv-color-navy);
+	font-weight: 500;
+	font-size: 0.9375rem;
+	padding: 0.5rem 1rem;
+	border-radius: var(--tv-radius);
+	transition: color 200ms ease, background-color 200ms ease;
+}
+
+.tv-back-link__a:hover,
+.tv-back-link__a:focus-visible {
+	color: var(--tv-color-brick);
+	background: rgba(255, 188, 33, 0.15); /* soft orange wash */
+}
+
+.tv-back-link__a:focus-visible {
+	outline: 2px solid var(--tv-color-orange);
+	outline-offset: 2px;
+}
+
+/* ---------------------------------------------------------- */
 /* Responsive                                                 */
 /* ---------------------------------------------------------- */
 

--- a/templates/single-training_videos.php
+++ b/templates/single-training_videos.php
@@ -174,6 +174,15 @@ include plugin_dir_path( __FILE__ ) . 'training-header.php';
 					<?php endif; ?>
 				</nav>
 
+				<!-- Back to all videos -->
+				<div class="tv-back-link mt-8 text-center">
+					<a href="<?php echo esc_url( get_post_type_archive_link( 'training_videos' ) ); ?>"
+					   class="tv-back-link__a inline-flex items-center gap-2">
+						<i class="fa-sharp fa-solid fa-arrow-left" aria-hidden="true"></i>
+						Back to all videos
+					</a>
+				</div>
+
 					<?php
 				endwhile;
 			else :

--- a/templates/training-header.php
+++ b/templates/training-header.php
@@ -46,4 +46,4 @@
 	</header>
 
 	<!-- Main Content Wrapper -->
-	<main class="min-h-screen">
+	<main class="tv-main">


### PR DESCRIPTION
## Summary

Pages had ~30-40% of vertical space empty under the main content because \`<main>\` forced \`min-h-screen\`. Footer floated mid-viewport on tall screens — pages felt unfinished.

- Drop \`min-h-screen\`, replace with \`.tv-main { min-height: 400px }\` so the page ends naturally above the footer
- Add a clear \"← Back to all videos\" link at the bottom of single pages (currently only the small PREV/NEXT arrows gave a way back)
- Soft orange-wash hover state, brick-colored text on focus

**Stacked on \`chore/v1.1.2-styling-baseline\`** (PR #19).

## Test plan

- [x] Single page at 1280px: footer sits comfortably under the back-link, no big empty band
- [x] Archive page: same result
- [x] Mobile (375px): footer doesn't crowd the content
- [x] Back-link is keyboard-focusable, has visible focus outline
- [ ] Eric eyeballs

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)