### PR TITLE
✨ Mobile video discovery — position label + back pill + slide-out drawer

### DIFF
--- a/css/training-videos.css
+++ b/css/training-videos.css
@@ -350,6 +350,266 @@ a.hover\:bg-beige\/50:hover { background-color: rgba(253, 249, 227, 0.50); }
 .btn:hover { background: var(--tv-color-brick); color: var(--tv-color-white); }
 
 /* ---------------------------------------------------------- */
+/* Mobile drawer + hamburger + back pill + position label     */
+/* ---------------------------------------------------------- */
+
+.tv-drawer-toggle {
+	display: none; /* desktop default — toggled in via media query below */
+	align-items: center;
+	justify-content: center;
+	width: 44px;
+	height: 44px;
+	padding: 0;
+	border: 0;
+	background: transparent;
+	color: var(--tv-color-white);
+	font-size: 1.25rem;
+	cursor: pointer;
+	border-radius: var(--tv-radius);
+	transition: background-color 200ms ease;
+}
+
+.tv-drawer-toggle:hover,
+.tv-drawer-toggle:focus-visible {
+	background: rgba(255, 255, 255, 0.20);
+}
+
+.tv-drawer-toggle:focus-visible {
+	outline: 2px solid var(--tv-color-orange);
+	outline-offset: 2px;
+}
+
+/* Visible only below lg */
+@media (max-width: 1023px) {
+	.tv-drawer-toggle { display: inline-flex; }
+}
+
+.tv-back-pill {
+	display: none; /* hidden by default; <lg shows it */
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.5rem 0.875rem;
+	margin-bottom: 1rem;
+	background: var(--tv-color-navy);
+	color: var(--tv-color-beige);
+	border-radius: 9999px;
+	font-size: 0.8125rem;
+	font-weight: 500;
+	transition: background-color 200ms ease;
+	width: fit-content;
+}
+
+.tv-back-pill:hover,
+.tv-back-pill:focus-visible {
+	background: var(--tv-color-stone-blue);
+	color: var(--tv-color-white);
+}
+
+@media (max-width: 1023px) {
+	.tv-back-pill { display: inline-flex; }
+}
+
+.tv-position {
+	display: inline-block;
+	font-size: 0.75rem;
+	font-weight: 500;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+	color: var(--tv-color-stone-blue);
+	margin-bottom: 0.5rem;
+}
+
+/* Drawer + backdrop */
+
+.tv-drawer-backdrop {
+	position: fixed;
+	inset: 0;
+	background: rgba(17, 45, 64, 0.50);
+	z-index: 99;
+	border: 0;
+	padding: 0;
+	cursor: pointer;
+	opacity: 0;
+	visibility: hidden;
+	transition: opacity 200ms ease, visibility 200ms ease;
+}
+
+.tv-drawer-backdrop[aria-hidden="false"] {
+	opacity: 1;
+	visibility: visible;
+}
+
+.tv-drawer {
+	position: fixed;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	width: min(85vw, 360px);
+	background: var(--tv-color-white);
+	z-index: 100;
+	transform: translateX(-100%);
+	transition: transform 220ms ease;
+	overflow-y: auto;
+	display: flex;
+	flex-direction: column;
+	box-shadow: 4px 0 24px -8px rgba(17, 45, 64, 0.30);
+}
+
+.tv-drawer[aria-hidden="false"] {
+	transform: translateX(0);
+}
+
+/* Lock body scroll while drawer is open */
+body.tv-drawer-open {
+	overflow: hidden;
+}
+
+.tv-drawer__head {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.75rem;
+	padding: 1rem 1.25rem;
+	background: var(--tv-color-navy);
+	color: var(--tv-color-white);
+}
+
+.tv-drawer__title {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	font-size: 1rem;
+	font-weight: 600;
+	margin: 0;
+}
+
+.tv-drawer__title .tv-drawer__count {
+	margin-left: 0.5rem;
+	font-weight: 400;
+	opacity: 0.65;
+	font-size: 0.875rem;
+}
+
+.tv-drawer__close {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 36px;
+	height: 36px;
+	padding: 0;
+	border: 0;
+	border-radius: var(--tv-radius);
+	background: rgba(255, 255, 255, 0.10);
+	color: var(--tv-color-white);
+	cursor: pointer;
+	font-size: 1rem;
+	transition: background-color 200ms ease;
+}
+
+.tv-drawer__close:hover,
+.tv-drawer__close:focus-visible {
+	background: rgba(255, 255, 255, 0.25);
+}
+
+.tv-drawer__list {
+	flex: 1 1 auto;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	overflow-y: auto;
+}
+
+.tv-drawer__list > li + li {
+	border-top: 1px solid var(--tv-color-linen);
+}
+
+.tv-drawer__item {
+	display: flex;
+	align-items: flex-start;
+	gap: 0.75rem;
+	padding: 0.875rem 1.25rem;
+	color: var(--tv-color-stone-blue);
+	font-size: 0.9375rem;
+	line-height: 1.35;
+	transition: background-color 200ms ease, color 200ms ease;
+}
+
+.tv-drawer__item:hover,
+.tv-drawer__item:focus-visible {
+	background: var(--tv-color-beige);
+	color: var(--tv-color-navy);
+}
+
+.tv-drawer__item.is-current {
+	background: var(--tv-color-beige);
+	border-left: 4px solid var(--tv-color-orange);
+	padding-left: calc(1.25rem - 4px);
+	color: var(--tv-color-navy);
+	font-weight: 500;
+}
+
+.tv-drawer__num {
+	flex-shrink: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.5rem;
+	height: 1.5rem;
+	border-radius: 9999px;
+	background: var(--tv-color-linen);
+	color: var(--tv-color-stone-blue);
+	font-size: 0.75rem;
+	font-weight: 500;
+}
+
+.tv-drawer__item.is-current .tv-drawer__num {
+	background: var(--tv-color-orange);
+	color: var(--tv-color-navy);
+}
+
+.tv-drawer__foot {
+	padding: 0.875rem 1.25rem;
+	border-top: 1px solid var(--tv-color-linen);
+	background: rgba(253, 249, 227, 0.5);
+}
+
+.tv-drawer__archive-link {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	color: var(--tv-color-navy);
+	font-size: 0.875rem;
+	font-weight: 500;
+	transition: color 200ms ease;
+}
+
+.tv-drawer__archive-link:hover,
+.tv-drawer__archive-link:focus-visible {
+	color: var(--tv-color-brick);
+}
+
+/* Hide drawer + backdrop entirely on lg+ since the sidebar fills the role */
+@media (min-width: 1024px) {
+	.tv-drawer,
+	.tv-drawer-backdrop {
+		display: none !important;
+	}
+}
+
+/* WP admin bar offset — only relevant in development (end users aren't logged in) */
+body.admin-bar .tv-drawer,
+body.admin-bar .tv-drawer-backdrop {
+	top: 32px;
+}
+
+@media (max-width: 782px) {
+	body.admin-bar .tv-drawer,
+	body.admin-bar .tv-drawer-backdrop {
+		top: 46px;
+	}
+}
+
+/* ---------------------------------------------------------- */
 /* Responsive                                                 */
 /* ---------------------------------------------------------- */
 

--- a/templates/single-training_videos.php
+++ b/templates/single-training_videos.php
@@ -98,8 +98,18 @@ include plugin_dir_path( __FILE__ ) . 'training-header.php';
 					the_post();
 					?>
 
+				<!-- Mobile-only "All videos" pill (lg+ uses the sidebar) -->
+				<a href="<?php echo esc_url( get_post_type_archive_link( 'training_videos' ) ); ?>"
+				   class="tv-back-pill">
+					<i class="fa-sharp fa-solid fa-arrow-left" aria-hidden="true"></i>
+					All videos
+				</a>
+
 				<!-- Video Title -->
 				<div class="mb-6">
+					<span class="tv-position">
+						Video <?php echo (int) $current_index + 1; ?> of <?php echo count( $all_videos ); ?>
+					</span>
 					<h1 class="text-navy mb-3"><?php the_title(); ?></h1>
 
 					<?php

--- a/templates/training-footer.php
+++ b/templates/training-footer.php
@@ -56,6 +56,48 @@
 	</script>
 	<?php endif; ?>
 
+	<script>
+	/* Mobile drawer toggle. Hamburger opens, backdrop/close/Escape close. */
+	(function () {
+		var toggle   = document.querySelector( '.tv-drawer-toggle' );
+		var drawer   = document.getElementById( 'tv-drawer' );
+		var backdrop = document.querySelector( '.tv-drawer-backdrop' );
+		if ( ! toggle || ! drawer ) { return; }
+
+		function isOpen() { return drawer.getAttribute( 'aria-hidden' ) === 'false'; }
+
+		function open() {
+			drawer.setAttribute( 'aria-hidden', 'false' );
+			if ( backdrop ) { backdrop.setAttribute( 'aria-hidden', 'false' ); }
+			toggle.setAttribute( 'aria-expanded', 'true' );
+			document.body.classList.add( 'tv-drawer-open' );
+			var firstFocusable = drawer.querySelector( 'a, button' );
+			if ( firstFocusable ) { firstFocusable.focus(); }
+		}
+
+		function close() {
+			drawer.setAttribute( 'aria-hidden', 'true' );
+			if ( backdrop ) { backdrop.setAttribute( 'aria-hidden', 'true' ); }
+			toggle.setAttribute( 'aria-expanded', 'false' );
+			document.body.classList.remove( 'tv-drawer-open' );
+			toggle.focus();
+		}
+
+		toggle.addEventListener( 'click', function () {
+			isOpen() ? close() : open();
+		} );
+
+		var closers = document.querySelectorAll( '[data-tv-drawer-close]' );
+		Array.prototype.forEach.call( closers, function ( el ) {
+			el.addEventListener( 'click', close );
+		} );
+
+		document.addEventListener( 'keydown', function ( e ) {
+			if ( e.key === 'Escape' && isOpen() ) { close(); }
+		} );
+	})();
+	</script>
+
 	<?php
 	// Include WordPress footer scripts
 	wp_footer();

--- a/templates/training-header.php
+++ b/templates/training-header.php
@@ -1,3 +1,17 @@
+<?php
+// Pull all training videos for the mobile drawer (visible <lg).
+$tv_drawer_videos = get_posts(
+	array(
+		'post_type'      => 'training_videos',
+		'orderby'        => 'menu_order',
+		'order'          => 'ASC',
+		'posts_per_page' => 100,
+		'post_status'    => 'publish',
+	)
+);
+$tv_archive_url    = get_post_type_archive_link( 'training_videos' );
+$tv_current_post_id = is_singular( 'training_videos' ) ? get_the_ID() : 0;
+?>
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>
 <head>
@@ -29,6 +43,14 @@
 
 				<!-- Navigation -->
 				<nav class="flex gap-2 items-center">
+					<button type="button"
+							class="tv-drawer-toggle"
+							aria-controls="tv-drawer"
+							aria-expanded="false"
+							aria-label="Open all videos menu">
+						<i class="fa-sharp fa-solid fa-bars" aria-hidden="true"></i>
+					</button>
+
 					<a href="<?php echo esc_url( home_url() ); ?>" class="inline-flex items-center gap-2 px-4 py-2 text-white/80 hover:text-white transition-colors text-sm">
 						<i class="fa-sharp fa-solid fa-arrow-left"></i>
 						<span class="hidden sm:inline">Back to Site</span>
@@ -44,6 +66,44 @@
 			</div>
 		</div>
 	</header>
+
+	<!-- Mobile drawer (visible <lg). Renders globally so archive + single both have it. -->
+	<div class="tv-drawer-backdrop" data-tv-drawer-close aria-hidden="true"></div>
+	<aside id="tv-drawer"
+	       class="tv-drawer"
+	       aria-label="All training videos"
+	       aria-hidden="true">
+		<div class="tv-drawer__head">
+			<h2 class="tv-drawer__title">
+				<i class="fa-sharp fa-solid fa-list" aria-hidden="true"></i>
+				All Videos
+				<span class="tv-drawer__count"><?php echo count( $tv_drawer_videos ); ?></span>
+			</h2>
+			<button type="button" class="tv-drawer__close" data-tv-drawer-close aria-label="Close menu">
+				<i class="fa-sharp fa-solid fa-xmark" aria-hidden="true"></i>
+			</button>
+		</div>
+		<ul class="tv-drawer__list">
+			<?php foreach ( $tv_drawer_videos as $tv_i => $tv_video ) :
+				$tv_is_current = ( $tv_current_post_id === $tv_video->ID ); ?>
+				<li>
+					<a href="<?php echo esc_url( get_permalink( $tv_video->ID ) ); ?>"
+					   class="tv-drawer__item<?php echo $tv_is_current ? ' is-current' : ''; ?>">
+						<span class="tv-drawer__num"><?php echo (int) $tv_i + 1; ?></span>
+						<span class="tv-drawer__label"><?php echo esc_html( $tv_video->post_title ); ?></span>
+					</a>
+				</li>
+			<?php endforeach; ?>
+		</ul>
+		<?php if ( $tv_archive_url ) : ?>
+			<div class="tv-drawer__foot">
+				<a href="<?php echo esc_url( $tv_archive_url ); ?>" class="tv-drawer__archive-link">
+					<i class="fa-sharp fa-solid fa-grid-2" aria-hidden="true"></i>
+					View All Videos
+				</a>
+			</div>
+		<?php endif; ?>
+	</aside>
 
 	<!-- Main Content Wrapper -->
 	<main class="min-h-screen">


### PR DESCRIPTION
## Summary

Mobile users on a single video page couldn't see the full video list — the desktop sidebar is \`lg+\` only. Three additions to the mobile experience:

1. **\"Video N of M\" position label** above each single-page title (always shown, gives orientation when the desktop sidebar is hidden)
2. **\"← All videos\" navy pill** below the header (visible <\`lg\`) — one tap to the archive
3. **Hamburger button** in the header (visible <\`lg\`) opens a slide-out drawer with the full numbered video list, current item highlighted (mirrors desktop sidebar styling)

**Drawer behavior:**
- Opens via hamburger, closes via × button, backdrop click, or Escape
- Body scroll locks while open
- Auto-focus moves to first interactive element; close returns focus to toggle
- \`aria-controls\` + \`aria-expanded\` on toggle, \`aria-hidden\` on drawer/backdrop
- Slides in from left, 220ms ease, soft drop-shadow
- Hidden entirely at \`lg+\` (desktop sidebar fills the role)
- WP admin bar offset for dev (real visitors aren't logged in, won't see this)

**Stacked on \`chore/v1.1.2-styling-baseline\`** (PR #19).

## Test plan

- [x] 375px single page: pill at top, position label near title, hamburger opens drawer
- [x] Drawer auto-focuses close button when opened
- [x] Drawer closes on × click, backdrop click, or Escape
- [x] Body scroll locks while drawer is open
- [x] Current video highlighted in drawer (orange number circle, beige bg, navy text)
- [x] 1024px+: pill hidden, hamburger hidden, drawer/backdrop hidden, sidebar visible (no regression)
- [ ] Eric eyeballs

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)